### PR TITLE
feat(home): connect People tab on bottom nav to matching screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -28,6 +28,9 @@ class _HomeScreenState extends State<HomeScreen> {
           if (index == 2) {
             Navigator.pushNamed(context, '/chat'); // route to chat screen
             return; // prevent changing index
+          } else if (index == 1) {
+            Navigator.pushNamed(context, '/people'); // route to people screen
+            return; // prevent changing index
           }
           setState(() => _selectedIndex = index);
         },


### PR DESCRIPTION
This PR connects the “People” tab on the bottom navigation bar on `home page`to the matching screen (`matches_screen.dart`). Users can now access swipeable profile cards by tapping the `People` icon, enabling match-based exploration and learning exchange.